### PR TITLE
Let XiVO use the returned results so as to use LDAP's clever matches

### DIFF
--- a/xivo_agid/directory/directory.py
+++ b/xivo_agid/directory/directory.py
@@ -71,9 +71,10 @@ class Context(object):
             try:
                 results = directory.lookup_reverse(number)
                 for result in results:
-                    if number in result.itervalues():
-                        logger.info("lookup_reverse result : %s", result)
-                        return result
+                    for res in result.itervalues():
+                        if re.match('^[0-9 -]+$', res) and re.sub('[ -]', '', res) == number:
+                            logger.info("lookup_reverse result : %s", result)
+                            return result
             except Exception:
                 logger.error('Error while looking up in directory %s for %s',
                              directory.name, number, exc_info=True)

--- a/xivo_agid/directory/directory.py
+++ b/xivo_agid/directory/directory.py
@@ -71,9 +71,8 @@ class Context(object):
             try:
                 results = directory.lookup_reverse(number)
                 for result in results:
-                    if number in result.itervalues():
-                        logger.info("lookup_reverse result : %s", result)
-                        return result
+                    logger.info("lookup_reverse result : %s", result)
+                    return result
             except Exception:
                 logger.error('Error while looking up in directory %s for %s',
                              directory.name, number, exc_info=True)

--- a/xivo_agid/directory/directory.py
+++ b/xivo_agid/directory/directory.py
@@ -71,8 +71,9 @@ class Context(object):
             try:
                 results = directory.lookup_reverse(number)
                 for result in results:
-                    logger.info("lookup_reverse result : %s", result)
-                    return result
+                    if number in result.itervalues():
+                        logger.info("lookup_reverse result : %s", result)
+                        return result
             except Exception:
                 logger.error('Error while looking up in directory %s for %s',
                              directory.name, number, exc_info=True)


### PR DESCRIPTION
the test "if number in result.itervalues():" was added to the code
on 10 Oct 2013: https://github.com/xivo-pbx/xivo-agid/commit/f51911053285495590ffabf492b8208a01ec583d
for "fix reverse lookup partial patches - Only complete numbers are
matched by a reverse lookup"
according to sebastien_ on IRC, this code was meant to address the
problem that a look-up of "1000" may match "4185551000" because the
number is contained in the string.
The problem with this approach is that the code throws away valid
results returned by clever backends such as LDAP, which return
results for "4185551000" whether LDAP contains "4185551000", "41 8555 1000" or
"41-8555-1000"
So, the correct approach is to let XiVO use the results here, and
address the problem in the way the LDAP filter is constructed, by
removing the wildcards in xivo_dird/directory/data_sources/ldap.py#L77
The other back-ends do not seem to use a wild-card approach, so the
overmatching problem seems only localized to LDAP
I believe that this patch and the one concerning
xivo_dird/directory/data_sources/ldap.py#L77 are addressing the same
issue which commit f51911053285495590ffabf492b8208a01ec583d tried to
address in 2013.