### PR TITLE
Update handle_fax.py

### DIFF
--- a/xivo_agid/modules/handle_fax.py
+++ b/xivo_agid/modules/handle_fax.py
@@ -48,7 +48,7 @@ def _convert_tiff_to_pdf(tifffile, pdffile=None):
 #   faxfile -- the path to the fax file (in TIFF format)
 #   dstnum -- the content of the the XIVO_DSTNUM dialplan variable
 #   args -- args specific to the backend
-def _new_mail_backend(subject, content_file, email_from, email_realname):
+def _new_mail_backend(subject, content_file, email_from, email_realname='XiVO Fax'):
     # Return a backend taking one additional argument, an email address,
     # which sends the fax file as a pdf to the given email address when
     # called.


### PR DESCRIPTION
1. Fax2ftp : New parameter ftp2pdf (True or False) into general section of xivo_fax.conf in order to have pdf file deposit on ftp directories instead of tiff file.
2. Fax2mail: New parameter email_realname  into mail section of xivo_fax.conf in order to personalize the realname of fax2mail service.